### PR TITLE
Adds 'edd_related_downloads_image_size' filter and checks image URL scheme in SSL sites

### DIFF
--- a/edd-related-downloads.php
+++ b/edd-related-downloads.php
@@ -173,8 +173,8 @@ array(
 					$eddrd_query->the_post();
 					if ($post->ID == $exclude_post_id) continue;
 					if(has_post_thumbnail()) {
-						$thumb = wp_get_attachment_image_src( get_post_thumbnail_id(), 'thumbnail' );
-						$thumbsrc = $thumb[0];
+						$thumb = wp_get_attachment_image_src( get_post_thumbnail_id(), apply_filters( 'edd_related_downloads_image_size', 'thumbnail' ) );
+						$thumbsrc = is_ssl() ? str_replace( 'http://', 'https://', $thumb[0] ) : $thumb[0];
 					}
 		            ?>
 	                <li>


### PR DESCRIPTION
Hi Isabel, I'm loving this plugin and how easy it's to work with it. Congrats on the great plugin.

This commit adds `edd_related_downloads_image_size` filter to modify the image size retrieved for featured image and checks if the image URL has the correct scheme in SSL environments.

The first one is because while there's already the `edd_related_downloads_image_src` a new call to wp_get_attachment_image_src would have to be made if all a user wants is to retrieve a different image size. With this filter, users can obtain the image size directly.

The latter is due to this Trac ticket
https://core.trac.wordpress.org/ticket/15928
and since wp_get_attachment_image_src uses image_downsize which uses wp_get_attachment_url.

All the best.
